### PR TITLE
fix spi bug in write_byte_2

### DIFF
--- a/Save_data/1.Save_Data.py
+++ b/Save_data/1.Save_Data.py
@@ -91,7 +91,7 @@ def read_byte_2(register):
  register_write=write|register
  data = [register_write,0x00,register]
  cs_line.set_value(0)
- read_reg=spi.xfer(data)
+ read_reg=spi_2.xfer(data)
  cs_line.set_value(1)
  print ("data", read_reg)
  


### PR DESCRIPTION
This pull request addresses issue #4.

`read_byte_2()` in Save_data/1.Save_Data.py has been updated to use `spi_2`