### PR TITLE
Add command line recording scripts

### DIFF
--- a/Save_data/1.Save_Data.py
+++ b/Save_data/1.Save_Data.py
@@ -91,7 +91,7 @@ def read_byte_2(register):
  register_write=write|register
  data = [register_write,0x00,register]
  cs_line.set_value(0)
- read_reg=spi_2.xfer(data)
+ read_reg=spi.xfer(data)
  cs_line.set_value(1)
  print ("data", read_reg)
  

--- a/Save_data/1.Save_Data.py
+++ b/Save_data/1.Save_Data.py
@@ -91,7 +91,7 @@ def read_byte_2(register):
  register_write=write|register
  data = [register_write,0x00,register]
  cs_line.set_value(0)
- read_reg=spi.xfer(data)
+ read_reg=spi_2.xfer(data)
  cs_line.set_value(1)
  print ("data", read_reg)
  

--- a/Save_data/command_line/pieeg_to_csv.py
+++ b/Save_data/command_line/pieeg_to_csv.py
@@ -1,0 +1,74 @@
+"""
+Record data from PiEEG-16 and write to CSV
+
+"""
+
+# imports
+import numpy as np
+from datetime import datetime
+from time import sleep
+import argparse
+
+from utils import setup_pieeg16, get_voltage
+
+
+def main():
+    # parse command line arguments
+    parser = argparse.ArgumentParser(description='Record ephys data.')
+    parser.add_argument('--fname', type=str, 
+                        help='Output filename of ephys data ')
+    parser.add_argument('--duration', type=int, default=600,
+                        help='Duration of recording (seconds). Default is 600 seconds')
+    parser.add_argument('--fs', type=int, default=10,
+                        help='Sampling frequency of the data (Hz). Default is 10 Hz')
+    parser.add_argument('--gain', type=int, default=1,
+                        help='Gain of the data (1, 2, 4, 6, 8, 12, or 24). Default is 1')
+    args = parser.parse_args()
+    if args.fname is None:
+        raise ValueError("Please input an output filename (--fname)")
+
+    # setup GPIO device (PiEEG-16)
+    print("\nSetting up recording device...")
+    print(f"  Recording settings:")
+    print(f"    Filename: {args.fname}")
+    print(f"    Duration: {args.duration} seconds")
+    print(f"    Sampling frequency: {args.fs} Hz")
+    print(f"    Gain: {args.gain}")
+    spi_1, spi_2, cs_line = setup_pieeg16(args.gain)
+
+    # initialize csv file for recording data
+    columns = "time,chan_1,chan_2,chan_3,chan_4,chan_5,chan_6,chan_7,chan_8,chan_9,chan_10,chan_11,chan_12,chan_13,chan_14,chan_15,chan_16\n"
+    with open(args.fname, 'w') as f:
+        f.write(columns)
+
+    # start clock
+    start_time = datetime.now()
+
+    # record data
+    print("\nRecording data...")
+    for i_sample in range(args.duration*args.fs):
+        # wait for sample time
+        if (datetime.now()-start_time).total_seconds() < (i_sample/args.fs):
+            sleep((i_sample/args.fs)-(datetime.now()-start_time).total_seconds())
+        timepoint = (datetime.now()-start_time).total_seconds()
+
+        # read data
+        output_1=spi_1.readbytes(27)
+        cs_line.set_value(0)
+        output_2=spi_2.readbytes(27)
+        cs_line.set_value(1)
+
+        data = np.zeros(16)
+        for a in range (3, 25, 3):
+            data[int(a/3)-1] = get_voltage(output_1, a)
+            data[int(a/3)+7] = get_voltage(output_2, a)
+
+        # write data
+        with open(args.fname, 'a') as f:
+            f.write(f"{timepoint}, {data[0]}, {data[1]}, {data[2]}, {data[3]}, {data[4]}, {data[5]}, {data[6]}, {data[7]}, {data[8]}, {data[9]}, {data[10]}, {data[11]}, {data[12]}, {data[13]}, {data[14]}, {data[15]}\n")
+            
+    print(f"Data saved to {args.fname}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Save_data/command_line/utils.py
+++ b/Save_data/command_line/utils.py
@@ -1,0 +1,197 @@
+
+# imports
+import spidev
+from RPi import GPIO
+GPIO.setwarnings(False) 
+GPIO.setmode(GPIO.BOARD)
+import gpiod
+
+
+def get_voltage(output, a, data_check=0xFFFFFF, data_test=0x7FFFFF):
+    voltage=(output[a]<<8) | output[a+1]
+    voltage=(voltage<<8) | output[a+2]
+    convert_voltage = voltage | data_test
+    if convert_voltage==data_check:
+        voltage = (voltage - 16777214)
+    voltage = round(1000000*4.5*(voltage/16777215),2)
+
+    return voltage
+    
+    
+def setup_pieeg16(gain=1):
+    # Convert gain to bits
+    gain = convert_gain(gain)
+
+    # GPIO settings
+    chip = gpiod.Chip("gpiochip4")
+
+    cs_line = chip.get_line(19)  # GPIO19
+    cs_line.request(consumer="SPI_CS", type=gpiod.LINE_REQ_DIR_OUT)
+    cs_line.set_value(1)  # Set CS high initially
+
+    # Initialize spidev
+    spi_1 = spidev.SpiDev()
+    spi_1.open(0,0)
+    spi_1.max_speed_hz  = 4000000
+    spi_1.lsbfirst=False
+    spi_1.mode=0b01
+    spi_1.bits_per_word = 8
+
+    spi_2 = spidev.SpiDev()
+    spi_2.open(0,1)
+    spi_2.max_speed_hz=4000000
+    spi_2.lsbfirst=False
+    spi_2.mode=0b01
+    spi_2.bits_per_word = 8
+
+    # Register Commands
+    who_i_am=0x00
+    config1=0x01
+    config2=0X02
+    config3=0X03
+
+    reset=0x06
+    stop=0x0A
+    start=0x08
+    sdatac=0x11
+    rdatac=0x10
+    wakeup=0x02
+    rdata = 0x12
+
+    ch1set=0x05
+    ch2set=0x06
+    ch3set=0x07
+    ch4set=0x08
+    ch5set=0x09
+    ch6set=0x0A
+    ch7set=0x0B
+    ch8set=0x0C
+
+    # device initialization and configuration - first 8 channels
+    send_command (spi_1, wakeup)
+    send_command (spi_1, stop)
+    send_command (spi_1, reset)
+    send_command (spi_1, sdatac)
+
+    write_byte (spi_1, 0x14, 0x80) #GPIO 80
+    write_byte (spi_1, config1, 0x96)
+    write_byte (spi_1, config2, 0xD4)
+    write_byte (spi_1, config3, 0xFF)
+    write_byte (spi_1, 0x04, 0x00)
+    write_byte (spi_1, 0x0D, 0x00)
+    write_byte (spi_1, 0x0E, 0x00)
+    write_byte (spi_1, 0x0F, 0x00)
+    write_byte (spi_1, 0x10, 0x00)
+    write_byte (spi_1, 0x11, 0x00)
+    write_byte (spi_1, 0x15, 0x20)
+
+    write_byte (spi_1, 0x17, 0x00)
+    write_byte (spi_1, ch1set, gain)
+    write_byte (spi_1, ch2set, gain)
+    write_byte (spi_1, ch3set, gain)
+    write_byte (spi_1, ch4set, gain)
+    write_byte (spi_1, ch5set, gain)
+    write_byte (spi_1, ch6set, gain)
+    write_byte (spi_1, ch7set, gain)
+    write_byte (spi_1, ch8set, gain)
+
+    send_command (spi_1, rdatac)
+    send_command (spi_1, start)
+
+    # device initialization and configuration - last 8 channels
+    send_command_2 (spi_2, cs_line, wakeup)
+    send_command_2 (spi_2, cs_line, stop)
+    send_command_2 (spi_2, cs_line, reset)
+    send_command_2 (spi_2, cs_line, sdatac)
+
+    write_byte_2 (spi_2, cs_line, 0x14, 0x80) #GPIO 80
+    write_byte_2 (spi_2, cs_line, config1, 0x96)
+    write_byte_2 (spi_2, cs_line, config2, 0xD4)
+    write_byte_2 (spi_2, cs_line, config3, 0xFF)
+    write_byte_2 (spi_2, cs_line, 0x04, 0x00)
+    write_byte_2 (spi_2, cs_line, 0x0D, 0x00)
+    write_byte_2 (spi_2, cs_line, 0x0E, 0x00)
+    write_byte_2 (spi_2, cs_line, 0x0F, 0x00)
+    write_byte_2 (spi_2, cs_line, 0x10, 0x00)
+    write_byte_2 (spi_2, cs_line, 0x11, 0x00)
+    write_byte_2 (spi_2, cs_line, 0x15, 0x20)
+
+    write_byte_2 (spi_2, cs_line, 0x17, 0x00)
+    write_byte_2 (spi_2, cs_line, ch1set, gain)
+    write_byte_2 (spi_2, cs_line, ch2set, gain)
+    write_byte_2 (spi_2, cs_line, ch3set, gain)
+    write_byte_2 (spi_2, cs_line, ch4set, gain)
+    write_byte_2 (spi_2, cs_line, ch5set, gain)
+    write_byte_2 (spi_2, cs_line, ch6set, gain)
+    write_byte_2 (spi_2, cs_line, ch7set, gain)
+    write_byte_2 (spi_2, cs_line, ch8set, gain)
+
+    send_command_2 (spi_2, cs_line, rdatac)
+    send_command_2 (spi_2, cs_line, start)
+
+    return spi_1, spi_2, cs_line
+
+
+# SPI Read/Write Functions
+def read_byte(spi, register):
+    write=0x20
+    register_write=write|register
+    data = [register_write,0x00,register]
+    spi.xfer(data)
+
+
+def send_command(spi, command):
+    send_data = [command]
+    spi.xfer(send_data)
+
+
+def write_byte(spi, register,data):
+    write=0x40
+    register_write=write|register
+    data = [register_write,0x00,data]
+    spi.xfer(data)
+
+
+def read_byte_2(spi_2, cs_line, register):
+    write=0x20
+    register_write=write|register
+    data = [register_write,0x00,register]
+    cs_line.set_value(0)
+    spi_2.xfer(data)
+    cs_line.set_value(1)
+
+
+def send_command_2(spi_2, cs_line, command):
+    send_data = [command]
+    cs_line.set_value(0)
+    spi_2.xfer(send_data)
+    cs_line.set_value(1)
+
+
+def write_byte_2(spi_2, cs_line, register, data):
+    write=0x40
+    register_write=write|register
+    data = [register_write,0x00,data]
+    cs_line.set_value(0)
+    spi_2.xfer(data)
+    cs_line.set_value(1)
+
+
+def convert_gain(value):
+# convert to bits
+    if value == 1:
+        return 0b000
+    elif value == 2:
+        return 0b001
+    elif value == 4:
+        return 0b010
+    elif value == 6:
+        return 0b011
+    elif value == 8:
+        return 0b100
+    elif value == 12:
+        return 0b101
+    elif value == 24:
+        return 0b110
+    else:
+        raise ValueError("Invalid gain value. Please use 1, 2, 4, 6, 8, 12, or 24.")


### PR DESCRIPTION
This pull requests add functionality for command line recordings. The recording script was inspired by ` Save_data/1.Save_Data.py` but can be run from the command line with several arguments (output filename, recording duration, sampling frequency, and gain). The most noteworthy difference is that the timestamp of each sample is recorded, and a consistent delay was added between samples. A few bugs were also fixed (those addressed in #3 and #5), and some unused code was removed.  A supporting utils script was also created; `utils.setup_pieeg16()` handles the GPIO setup and could be leveraged by other scripts e.g. ` Save_data/1.Save_Data.py`; while `utils.get_voltage` converts the reading to volts. 