### PR TITLE
Update code to solve cannot find the "/dev/gpiochip4"

### DIFF
--- a/GUI/2.Graph_Gpio_D _1_5_4.py
+++ b/GUI/2.Graph_Gpio_D _1_5_4.py
@@ -14,7 +14,8 @@ button_pin_2 =  13
 cs_pin = 19
 #chip = gpiod.Chip("gpiochip4")
 print ("ok1")
-chip = gpiod.chip("/dev/gpiochip4")
+# chip = gpiod.chip("/dev/gpiochip4")
+chip = gpiod.chip("0")
 print ("ok2")
 #cs_line = chip.get_line(19)  # GPIO19
 print ("ok3")


### PR DESCRIPTION
Hi @Ildaron, after my different attempts, I found the right way to solve this problem, just by changing one line of code.

`chip = gpiod.chip("/dev/gpiochip4") ` ==> `chip = gpiod.chip("0")`

- Raspberry Pi 5
- python version 3.11.2 & 3.12 both OK
```
Package         Version
--------------- -----------
contourpy       1.3.1
cycler          0.12.1
fonttools       4.56.0
gpiod           1.5.4
kiwisolver      1.4.8
matplotlib      3.10.0
numpy           2.2.3
packaging       24.2
pillow          11.1.0
pip             23.0.1
pyparsing       3.2.1
python-dateutil 2.9.0.post0
scipy           1.15.2
setuptools      66.1.1
six             1.17.0
spidev          3.6
```
![image](https://github.com/user-attachments/assets/7228411d-f9af-410e-8825-10a17f458216)
